### PR TITLE
Default reading method converted in [uT]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 use embedded_hal::blocking::i2c::{Write, WriteRead};
 
 const AK09915_ADDRESS: u8 = 0x0C;
+///Magnetic sensor sensitivity (BSE) for Ta = 25 ˚C [µT/LSB],  Typical 0.15 +- 0.0075
+const AK09915_FLUX_CONSTANT: f32 = 0.15;
 
 // Register Addresses
 #[repr(u16)]
@@ -158,6 +160,17 @@ where
             return Err(Error::SensorOverflow);
         }
         Ok(())
+    }
+
+    // Return the readings in magnetic flux density [uT]
+    pub fn read(&mut self) -> Result<(f32, f32, f32), Error<E>> {
+        let raw_data = self.read_raw()?;
+        let scaled_data = (
+            raw_data.0 as f32 * AK09915_FLUX_CONSTANT,
+            raw_data.1 as f32 * AK09915_FLUX_CONSTANT,
+            raw_data.2 as f32 * AK09915_FLUX_CONSTANT,
+        );
+        Ok(scaled_data)
     }
 
     // 9.4.3.2. Normal Read Sequence:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ where
     pub fn self_test(&mut self) -> Result<bool, Error<E>> {
         self.set_mode(Mode::SelfTest)?;
         std::thread::sleep(std::time::Duration::from_micros(4000));
-        let (hx, hy, hz) = self.read()?;
+        let (hx, hy, hz) = self.read_raw()?;
         // Self-test judgment
         if (-200..=200).contains(&hx) && (-200..=200).contains(&hy) && (-800..=-200).contains(&hz) {
             println!(
@@ -181,7 +181,7 @@ where
     //      By reading ST2 register, this protection is released. It is required to read
     //      ST2 register after data reading.
 
-    pub fn read(&mut self) -> Result<(i16, i16, i16), Error<E>> {
+    pub fn read_raw(&mut self) -> Result<(i16, i16, i16), Error<E>> {
         self.check_data_ready()?;
         let res = self.read_unchecked();
         self.check_overflow()?;


### PR DESCRIPTION
Change the old reading values to read_raw.
New read return measurements in [uT]
![image](https://github.com/bluerobotics/AK09915-rs/assets/80598030/c0c3e4ef-693b-4fe4-b576-bc41a054b721)
