### PR TITLE
Fix: Reading optimization ( add custom timing for each mode )

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub enum Register {
 
 // AK09915 Mode Settings - Corresponding to Control Register 2
 #[repr(u16)]
+#[derive(Clone, Copy)]
 pub enum Mode {
     PowerDown = 0x00,
     Single = 0x01,
@@ -61,6 +62,7 @@ impl From<Register> for u8 {
 pub struct Ak09915<I2C> {
     pub i2c: I2C,
     pub address: u8,
+    pub mode: Mode,
 }
 
 impl<I2C, E> Ak09915<I2C>
@@ -71,6 +73,7 @@ where
         Self {
             i2c,
             address: AK09915_ADDRESS,
+            mode: Mode::PowerDown,
         }
     }
 
@@ -105,6 +108,7 @@ where
         self.write_register(Register::CNTL2, Mode::PowerDown.into())?;
         std::thread::sleep(std::time::Duration::from_micros(100));
         self.write_register(Register::CNTL2, mode.into())?;
+        self.mode = mode;
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ where
     }
 
     pub fn check_data_ready(&mut self) -> Result<(), Error<E>> {
-        let retries = 10;
+        let retries = 3;
         for _ in 0..retries {
             let status = self.read_register(Register::ST1)?;
             if (status & 0x01) != 0 {


### PR DESCRIPTION
Previous readings were reaching 90.271 ms, 
with this PR, they have been reduced to 5 ms, which is what is expected from the 200 Hz mode on the sensor.

Criterion Plot:
![iteration_times](https://github.com/bluerobotics/AK09915-rs/assets/80598030/571b637f-d44a-4b81-bf97-8b109b692173)

Critetion Output:
```
blueos@raspberrypi-armv7:~/github/AK09915-rs $ cargo bench --bench bench -- --measurement-time 10
   Compiling ak09915_rs v0.1.0 (/home/blueos/github/AK09915-rs)
    Finished bench [optimized] target(s) in 15.06s
     Running benches/bench.rs (target/release/deps/bench-960d91f9648acce3)
Gnuplot not found, using plotters backend
new                     time:   [18.560 µs 18.906 µs 19.276 µs]
                        change: [-2.1175% +1.2418% +5.2751%] (p = 0.52 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

read_register           time:   [436.26 µs 438.36 µs 440.34 µs]
                        change: [-2.0691% -0.9763% -0.1142%] (p = 0.04 < 0.05)
                        Change within noise threshold.

read                    time:   [4.9723 ms 4.9799 ms 4.9895 ms]
                        change: [-94.721% -94.483% -94.199%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low severe
  3 (3.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe
```