### PR TITLE
Add: Benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,10 @@ embedded-hal = "0.2.5"
 
 [dev-dependencies]
 clap = { version = "4.2.2", features = ["derive"] }
+criterion = { version = "0.5.1", features = ["html_reports"] }
 embedded-hal-mock = "0.9.0"
 linux-embedded-hal = "0.3.2"
+
+[[bench]]
+name = "bench"
+harness = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -10,11 +10,11 @@ fn new() -> Ak09915<I2cdev> {
 fn ak09915(c: &mut Criterion) {
     #[macro_export]
     macro_rules! bench {
-    ($bench_fn:ident($($arg:tt)*)) => {
-        let mut sensor = new();
-        sensor.set_mode(Mode::Cont200Hz).unwrap();
-        c.bench_function(stringify!($bench_fn), |b| b.iter(|| sensor.$bench_fn($($arg)*)));
-    }}
+        ($bench_fn:ident($($arg:tt)*)) => {
+            let mut sensor = new();
+            sensor.set_mode(Mode::Cont200Hz).unwrap();
+            c.bench_function(stringify!($bench_fn), |b| b.iter(|| sensor.$bench_fn($($arg)*).expect("Error during benchmark")));
+        }}
 
     c.bench_function("new", |b| b.iter(|| new()));
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,26 @@
+use ak09915_rs::{Ak09915, Mode, Register};
+use criterion::{criterion_group, criterion_main, Criterion};
+use linux_embedded_hal::I2cdev;
+
+fn new() -> Ak09915<I2cdev> {
+    let dev = I2cdev::new("/dev/i2c-1").unwrap();
+    Ak09915::new(dev)
+}
+
+fn ak09915(c: &mut Criterion) {
+    #[macro_export]
+    macro_rules! bench {
+    ($bench_fn:ident($($arg:tt)*)) => {
+        let mut sensor = new();
+        sensor.set_mode(Mode::Cont200Hz).unwrap();
+        c.bench_function(stringify!($bench_fn), |b| b.iter(|| sensor.$bench_fn($($arg)*)));
+    }}
+
+    c.bench_function("new", |b| b.iter(|| new()));
+
+    bench!(read_register(Register::ST1));
+    bench!(read());
+}
+
+criterion_group!(benches, ak09915);
+criterion_main!(benches);


### PR DESCRIPTION
This PR adds benchmarking to our library. 
It should be upgraded for testing different modes (100, 50, ...) and other operations.

How to use: 
`cargo bench --bench bench
`

Currently, it measures the AK09915 reading operation at 200 Hz and also measures the time required to create the sensor object and read a single register."

Criterion's plot:
![iteration_times](https://github.com/bluerobotics/AK09915-rs/assets/80598030/93d719c8-fe5b-419c-9ee7-f6f814605488)

Previous vs Actual:
![iteration_times](https://github.com/bluerobotics/AK09915-rs/assets/80598030/45b2eec8-aab3-4f87-be1e-601bf1509f2b)
