### PR TITLE
Benchmark : Add macro and test different modes

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -15,11 +15,27 @@ fn ak09915(c: &mut Criterion) {
             sensor.set_mode(Mode::Cont200Hz).unwrap();
             c.bench_function(stringify!($bench_fn), |b| b.iter(|| sensor.$bench_fn($($arg)*).expect("Error during benchmark")));
         }}
+    macro_rules! reading {
+        ($name:ident) => {
+            let mut sensor = new();
+            sensor.set_mode(Mode::$name).unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(500));
+            c.bench_function(stringify!($name), |b| {
+                b.iter(|| sensor.read().expect("Error during benchmark"))
+            });
+        };
+    }
 
     c.bench_function("new", |b| b.iter(|| new()));
 
     bench!(read_register(Register::ST1));
     bench!(read());
+
+    reading!(Cont1Hz);
+    reading!(Cont10Hz);
+    reading!(Cont50Hz);
+    reading!(Cont100Hz);
+    reading!(Cont200Hz);
 }
 
 criterion_group!(benches, ak09915);


### PR DESCRIPTION
Add benchmark tests to validade the continuous modes.

Actual master:
```
blueos@raspberrypi-armv7:~/github/AK09915-rs $ cargo bench

   Compiling ak09915_rs v0.1.0 (/home/blueos/github/AK09915-rs)
    Finished bench [optimized] target(s) in 16.94s
     Running unittests src/lib.rs (target/release/deps/ak09915_rs-0976d8e076b8b2bb)

running 1 test
test tests::set_mode_and_read_sensor ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/bench.rs (target/release/deps/bench-4e5f0b06181b05d7)
Gnuplot not found, using plotters backend
new                     time:   [18.256 µs 18.687 µs 19.140 µs]
                        change: [-3.4750% -0.2078% +3.0719%] (p = 0.90 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

read_register           time:   [439.70 µs 441.53 µs 443.18 µs]
                        change: [+0.5894% +1.0565% +1.5539%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 30 outliers among 100 measurements (30.00%)
  13 (13.00%) low severe
  17 (17.00%) high severe

Benchmarking read: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.8s, or reduce sample count to 50.
read                    time:   [83.253 ms 90.288 ms 96.324 ms]
                        change: [-7.3915% +3.4465% +15.219%] (p = 0.55 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  12 (12.00%) low severe
  2 (2.00%) high mild

Benchmarking Cont1Hz: Warming up for 3.0000 sthread 'main' panicked at benches/bench.rs:38:5:
Error during benchmark, reason: DataNotReady
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

error: bench failed, to rerun pass `--bench bench`
```

Future branch tested [WIP]:
```
....
Cont1Hz                 time:   [1.0024 s 1.0024 s 1.0024 s]
                        change: [+0.0011% +0.0019% +0.0028%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high severe

Benchmarking Cont10Hz: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.8s, or reduce sample count to 50.
Cont10Hz                time:   [96.820 ms 99.356 ms 101.87 ms]
                        change: [-5.8966% -2.9377% -0.9503%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 20 outliers among 100 measurements (20.00%)
  14 (14.00%) low severe
  2 (2.00%) high mild
  4 (4.00%) high severe

Cont50Hz                time:   [19.680 ms 19.922 ms 20.188 ms]
                        change: [-11.309% -9.7749% -8.0895%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 32 outliers among 100 measurements (32.00%)
  12 (12.00%) low severe
  1 (1.00%) low mild
  1 (1.00%) high mild
  18 (18.00%) high severe

Cont100Hz               time:   [9.8766 ms 9.9450 ms 10.008 ms]
                        change: [-17.406% -16.113% -14.717%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  16 (16.00%) low severe

Cont200Hz               time:   [4.9608 ms 4.9858 ms 5.0131 ms]
                        change: [-29.224% -28.432% -27.589%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
  ```