### PR TITLE
Fix: Reading optimization ( add overflow checking into same buffer )

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ where
     //      |ST2| -> | 0 0 0 0 HOFL INV 0 0 |
     pub fn check_overflow(&mut self) -> Result<(), Error<E>> {
         let status = self.read_register(Register::ST2)?;
-        if (status & 0x04) != 0 {
+        if (status & 0x08) != 0 {
             return Err(Error::SensorOverflow);
         }
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,9 +191,21 @@ where
 
     pub fn read_raw(&mut self) -> Result<(i16, i16, i16), Error<E>> {
         self.check_data_ready()?;
-        let res = self.read_unchecked();
-        self.check_overflow()?;
-        res
+
+        let mut buffer: [u8; 8] = [0u8; 8];
+        self.i2c
+            .write_read(self.address, &[Register::HXL.into()], &mut buffer)
+            .map_err(Error::I2C)?;
+
+        // Check the HOFL bit from ST2 register
+        if (buffer[7] & 0x08) != 0 {
+            return Err(Error::SensorOverflow);
+        }
+
+        let x = i16::from_le_bytes([buffer[0], buffer[1]]);
+        let y = i16::from_le_bytes([buffer[2], buffer[3]]);
+        let z = i16::from_le_bytes([buffer[4], buffer[5]]);
+        Ok((x, y, z))
     }
 
     pub fn read_unchecked(&mut self) -> Result<(i16, i16, i16), Error<E>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,11 +225,14 @@ mod tests {
     use super::*;
     use embedded_hal_mock::i2c::{Mock as I2cMock, Transaction as I2cTrans};
     #[test]
-    fn set_mode_and_read_sensor() {
-        // Define expected I2C transactions for setting mode and reading sensor data
+    fn read_sensor() {
         let expected_trans = [
-            // I2cTrans::write(0x0C, vec![0x31, 0x10]), // Set mode to continuous measurement mode 1
-            I2cTrans::write_read(0x0C, vec![0x11], vec![0x04, 0x23, 0x05, 0x24, 0x06, 0x25]), // Read sensor data
+            I2cTrans::write_read(AK09915_ADDRESS, vec![Register::ST1.into()], vec![0x01]),
+            I2cTrans::write_read(
+                AK09915_ADDRESS,
+                vec![Register::HXL.into()],
+                vec![0x04, 0x23, 0x05, 0x24, 0x06, 0x25, 0x00, 0x01],
+            ),
         ];
 
         // Create a mock I2C device and queue the expected transactions
@@ -238,10 +241,7 @@ mod tests {
         // Create an AK09915 instance using the mock I2C device
         let mut sensor = Ak09915::new(i2c_mock);
 
-        // Set the mode to continuous measurement mode 1
-        // sensor.set_mode(Mode::Cont1Hz).unwrap();
-
-        let (x, y, z) = sensor.read_unchecked().expect("Error reading magnetometer");
+        let (x, y, z) = sensor.read_raw().expect("Error reading magnetometer");
 
         // Verify that the magnetometer data matches the expected values
         assert_eq!(x, 0x2304);


### PR DESCRIPTION
Minimal optimization. Check overflow necessary byte into same read_raw function. 
- reduces a a unnecessary data_overflow request send to i2c. ( just receive sensor data and the next 2 bytes or this checking).

Test for 200Hz reading.
```
change: [-1.0791% -0.2770% +0.5069%] (p = 0.51 > 0.05)
No change in performance detected.
```