### PR TITLE
Update embedded hal to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["embedded"]
 keywords = ["magnetometer", "sensor", "embedded", "ak09915", "AsahiKASEI"]
 
 [dependencies]
-embedded-hal = "0.2.5"
+embedded-hal = "1.0.0"
 
 [dev-dependencies]
 clap = { version = "4.2.2", features = ["derive"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
-embedded-hal-mock = "0.9.0"
-linux-embedded-hal = "0.3.2"
+embedded-hal-mock = { version = "0.10.0", features = ["eh1"] }
+linux-embedded-hal = "0.4"
 
 [[bench]]
 name = "bench"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,5 +307,7 @@ mod tests {
         assert_eq!(x, 0x2304);
         assert_eq!(y, 0x2405);
         assert_eq!(z, 0x2506);
+
+        sensor.i2c.done();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use embedded_hal::blocking::i2c::{Write, WriteRead};
+use embedded_hal::i2c::I2c;
 
 const AK09915_ADDRESS: u8 = 0x0C;
 ///Magnetic sensor sensitivity (BSE) for Ta = 25 ˚C [µT/LSB],  Typical 0.15 +- 0.0075
@@ -87,7 +87,7 @@ pub struct Ak09915<I2C> {
 
 impl<I2C, E> Ak09915<I2C>
 where
-    I2C: Write<Error = E> + WriteRead<Error = E>,
+    I2C: I2c<Error = E>,
 {
     pub fn new(i2c: I2C) -> Self {
         Self {
@@ -283,7 +283,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use embedded_hal_mock::i2c::{Mock as I2cMock, Transaction as I2cTrans};
+    use embedded_hal_mock::eh1::i2c::{Mock as I2cMock, Transaction as I2cTrans};
     #[test]
     fn read_sensor() {
         let expected_trans = [


### PR DESCRIPTION
This update allows embedded-hal 1.0.0 versions to work, allowing GPIO [cdev pin access](https://github.com/rust-embedded/gpio-cdev#sysfs-gpio-vs-gpio-character-device) transitively through the [v0.4 update](https://crates.io/crates/linux-embedded-hal) of linux-embedded-hal as a result of the deprecation and removal of sysfs GPIO.